### PR TITLE
Fix test_strtotime failing on non-UTC systems

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -8,7 +8,7 @@ class PythonPHPTestCase(unittest.TestCase):
     """Just because something is tested, doesn't mean it is safe"""
 
     def test_strtotime(self):
-        r = php.strtotime("2015-01-01")
+        r = php.strtotime("2015-01-01 UTC")
         self.assertEqual(r, 1420070400)
 
     def test_str_replace(self):


### PR DESCRIPTION
This test fails on my machine (different timezone), and it's fixed by appending " UTC" to the date string.
